### PR TITLE
Non-generated Ormlite ID fields cause "Proper ID is not defined for field."

### DIFF
--- a/ormlite-content-provider-library/src/com/tojc/ormlite/android/framework/TableInfo.java
+++ b/ormlite-content-provider-library/src/com/tojc/ormlite/android/framework/TableInfo.java
@@ -82,10 +82,12 @@ public class TableInfo implements Validity {
                 ColumnInfo columnInfo = new ColumnInfo(classfield);
                 this.columns.put(columnInfo.getColumnName(), columnInfo);
 
-                // check id
+                // check id (generated or otherwise)
                 if (columnInfo.getColumnName().equals(BaseColumns._ID)) {
                     boolean generatedId = classfield.getAnnotation(DatabaseField.class).generatedId();
-                    if (generatedId) {
+                    boolean nonGeneratedId = classfield.getAnnotation(DatabaseField.class).id();
+
+                    if (generatedId || nonGeneratedId) {
                         this.idColumnInfo = columnInfo;
                     }
                 }


### PR DESCRIPTION
The code in `TableInfo.java` seems to require that your Ormlite ID field on your POJO be generated.  In my case, I have this instead:

``` java
@DatabaseField(columnName = BaseColumns._ID, id = true)
```

I'm doing this because IDs come from the external service.  However, is this possibly an antipattern? Is there some core assumption in OrmLiteContentProvider that would be broken if I modified this check to include id fields as well as generatedId fields?

Cheers. :)
